### PR TITLE
refactor: use String for extension identifiers in metadata structures

### DIFF
--- a/pvq-extension/src/metadata.rs
+++ b/pvq-extension/src/metadata.rs
@@ -1,4 +1,5 @@
 use crate::ExtensionIdTy;
+use scale_info::prelude::string::{String, ToString};
 
 // This trait is for ExtensionImpl
 pub trait ExtensionImplMetadata {
@@ -17,7 +18,8 @@ use serde::Serialize;
 #[derive(Clone, PartialEq, Eq, Encode, Debug, Serialize)]
 pub struct Metadata {
     pub types: PortableRegistry,
-    pub extensions: BTreeMap<ExtensionIdTy, ExtensionMetadata<PortableForm>>,
+    // Use String to prevent loss of precision in frontend codes
+    pub extensions: BTreeMap<String, ExtensionMetadata<PortableForm>>,
 }
 
 impl Metadata {
@@ -25,7 +27,7 @@ impl Metadata {
         let mut registry = Registry::new();
         let extensions = extensions
             .into_iter()
-            .map(|(id, metadata)| (id, metadata.into_portable(&mut registry)))
+            .map(|(id, metadata)| (id.to_string(), metadata.into_portable(&mut registry)))
             .collect();
         Self {
             types: registry.into(),

--- a/pvq-program-metadata-gen/src/metadata_gen.rs
+++ b/pvq-program-metadata-gen/src/metadata_gen.rs
@@ -219,7 +219,7 @@ fn import_packages() -> proc_macro2::TokenStream {
         use parity_scale_codec::Encode;
         use scale_info::{
             form::{Form, MetaForm, PortableForm},
-            prelude::vec::Vec,
+            prelude::{string::{String, ToString}, vec::Vec},
             IntoPortable, PortableRegistry, Registry,
         };
     }
@@ -232,7 +232,8 @@ fn metadata_defs() -> proc_macro2::TokenStream {
         #[derive(Clone, PartialEq, Eq, Encode, Debug, Serialize)]
         pub struct Metadata {
             pub types: PortableRegistry,
-            pub extension_fns: Vec<(ExtensionId, FnIndex, FunctionMetadata<PortableForm>)>,
+            // Use String to prevent loss of precision in frontend codes
+            pub extension_fns: Vec<(String, FnIndex, FunctionMetadata<PortableForm>)>,
             pub entrypoints: Vec<FunctionMetadata<PortableForm>>,
         }
 
@@ -241,7 +242,7 @@ fn metadata_defs() -> proc_macro2::TokenStream {
                 let mut registry = Registry::new();
                 let extension_fns = extension_fns
                     .into_iter()
-                    .map(|(id, index, metadata)| (id, index, metadata.into_portable(&mut registry)))
+                    .map(|(id, index, metadata)| (id.to_string(), index, metadata.into_portable(&mut registry)))
                     .collect();
                 let entrypoints = entrypoints
                     .into_iter()


### PR DESCRIPTION
* Updated Metadata struct to use String for extensions and extension_fns to prevent loss of precision in frontend codes.
* Adjusted related mapping logic to convert identifiers to String.